### PR TITLE
making compatible with ARM device deployment

### DIFF
--- a/hackathon/core-dns/docker-compose.yml
+++ b/hackathon/core-dns/docker-compose.yml
@@ -9,11 +9,6 @@ services:
    - ./Corefile:/etc/coredns/Corefile
   restart: always
   privileged: true
-  cpu_count: 1
-  cpu_percent: 20
-  cpus: 0.1
-  mem_limit: 1000000000
-  mem_reservation: 200m
   entrypoint: 
    - '/coredns'
    - '-conf'


### PR DESCRIPTION
Target ARM device is not supporting CPU quota management (not adding cgroup mount yet). So, removing resource constraints